### PR TITLE
一覧画面のパーツ修正(closes #13)

### DIFF
--- a/src/main/java/com/example/demo/controllers/ItemListController.java
+++ b/src/main/java/com/example/demo/controllers/ItemListController.java
@@ -1,14 +1,19 @@
 package com.example.demo.controllers;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import com.example.demo.entity.Brand;
+import com.example.demo.entity.DemoItem;
+import com.example.demo.repositories.BrandRepository;
 import com.example.demo.repositories.DemoItemRepository;
 
 import lombok.extern.slf4j.Slf4j;
-
 
 @Slf4j // ログ出力
 @Controller
@@ -17,10 +22,34 @@ public class ItemListController {
     @Autowired
     private DemoItemRepository demoItemRepository;
 
+    @Autowired
+    private BrandRepository brandRepository;
+
     @GetMapping("/demo_list")
-    public String showList(Model model) {
-        model.addAttribute("demoItems", demoItemRepository.findAll());
+    public String showList(
+            @RequestParam(required = false) Long brand, // ブランド
+            @RequestParam(required = false) String keyword, // キーワード
+            Model model) {
+
+        // ブランドを取得（プルダウン表示）
+        List<Brand> brands = brandRepository.findAll();
+        model.addAttribute("brands", brands);
+
+        // 検索条件に応じた抽出処理
+        List<DemoItem> demoItems;
+
+        if ((brand == null || brand == 0) && (keyword == null || keyword.isBlank())) {
+            demoItems = demoItemRepository.findAll(); //検索条件なし：全件表示
+        } else {
+            demoItems = demoItemRepository.searchByConditions(brand, keyword); //条件付き検索
+        }
+
+        model.addAttribute("demoItems", demoItems);
+
+        // 検索条件の保持（再表示）
+        model.addAttribute("selectedBrandId", brand);
+        model.addAttribute("keyword", keyword);
+
         return "demo_list"; // demo_list.html は DBの内容を使って表示するように
     }
 }
-

--- a/src/main/java/com/example/demo/repositories/DemoItemRepository.java
+++ b/src/main/java/com/example/demo/repositories/DemoItemRepository.java
@@ -12,8 +12,8 @@ import com.example.demo.entity.DemoItem;
 @Repository
 public interface DemoItemRepository extends JpaRepository<DemoItem, Long> {
 
-    @Query("SELECT d FROM DemoItem d WHERE "
-    +"(:brandId IS NULL OR :brandId = 0 OR d.brand.brandId = :brandId) AND "
-    +"(:keyword IS NULL OR d.demoName LIKE %:keyword%)")
+    @Query("SELECT d FROM DemoItem d WHERE "+
+    "(:brandId IS NULL OR d.brand.brandId = :brandId) AND "+
+    "(:keyword IS NULL OR d.demoName LIKE %:keyword% OR d.comment LIKE %:keyword%)")
     List<DemoItem> searchByConditions(@Param("brandId") Long brandId, @Param("keyword") String keyword);
 }

--- a/src/main/java/com/example/demo/repositories/DemoItemRepository.java
+++ b/src/main/java/com/example/demo/repositories/DemoItemRepository.java
@@ -1,11 +1,19 @@
 package com.example.demo.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.demo.entity.DemoItem;
 
 @Repository
 public interface DemoItemRepository extends JpaRepository<DemoItem, Long> {
-    
+
+    @Query("SELECT d FROM DemoItem d WHERE "
+    +"(:brandId IS NULL OR :brandId = 0 OR d.brand.brandId = :brandId) AND "
+    +"(:keyword IS NULL OR d.demoName LIKE %:keyword%)")
+    List<DemoItem> searchByConditions(@Param("brandId") Long brandId, @Param("keyword") String keyword);
 }

--- a/src/main/resources/templates/demo_list.html
+++ b/src/main/resources/templates/demo_list.html
@@ -57,7 +57,7 @@
                 <div class="col d-flex flex-row-reverse">
                     <button type="submit" class="btn btn-success">検索</button>
                     <a th:href="@{/demo_list}" class="btn btn-secondary ms-1 me-1">リセット</a>
-                    <a th:href="@{/demo_form}" class="btn btn-primary">新規登録</button>
+                    <a th:href="@{/demo_form}" class="btn btn-primary">新規登録</a>
                 </div>
             </div>
         </form>

--- a/src/main/resources/templates/demo_list.html
+++ b/src/main/resources/templates/demo_list.html
@@ -32,31 +32,35 @@
         </div>
     </nav>
     <div class="container">
-        <div class="row">
-            <div class="col">
-                <div class="mb-3">
-                    <label for="brand" class="form-label">ブランド</label>
-                    <select class="form-select" id="brand">
-                        <option value="">ブランドを選択</option>
-                        <option th:each="brand : ${brands}" th:value="${brand.brandId}" th:text="${brand.brandName}">
-                        </option>
-                    </select>
+
+        <form th:action="@{/demo_list}" method="get">
+            <div class="row">
+                <div class="col">
+                    <div class="mb-3">
+                        <label for="brand" class="form-label">ブランド</label>
+                        <select class="form-select" id="brand" name="brand">
+                            <option value="">ブランドを選択</option>
+                            <option th:each="brand : ${brands}" th:value="${brand.brandId}"
+                                th:text="${brand.brandName}" th:selected="${brand.brandId == selectedBrandId}">
+                            </option>
+                        </select>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="mb-3">
+                        <label for="keyword" class="form-label">キーワード</label>
+                        <input type="text" class="form-control" id="keyword" name="keyword" th:value="${keyword}">
+                    </div>
                 </div>
             </div>
-            <div class="col">
-                <div class="mb-3">
-                    <label for="keyword" class="form-label">キーワード</label>
-                    <input type="text" class="form-control" id="keyword" placeholder="">
+            <div class="row">
+                <div class="col d-flex flex-row-reverse">
+                    <button type="submit" class="btn btn-success">検索</button>
+                    <a th:href="@{/demo_list}" class="btn btn-secondary ms-1 me-1">リセット</a>
+                    <a th:href="@{/demo_form}" class="btn btn-primary">新規登録</button>
                 </div>
             </div>
-        </div>
-        <div class="row">
-            <div class="col d-flex flex-row-reverse">
-                <button type="button" class="btn btn-primary">新規</button>
-                <button type="button" class="btn btn-secondary ms-1 me-1">リセット</button>
-                <button type="button" class="btn btn-success">検索</button>
-            </div>
-        </div>
+        </form>
 
         <div class="row">
             <div class="col">
@@ -86,10 +90,10 @@
         </div>
     </div>
 
-    
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
-        crossorigin="anonymous"></script> 
+        crossorigin="anonymous"></script>
 
 </body>
 


### PR DESCRIPTION
以下、一覧画面のパーツ修正

・ブランド：プルダウンで選択し、検索できるように修正
・キーワード：キーワードを入れて検索できるように修正
・各ボタンの「新規登録」、「リセット」、「検索」も正常に機能するよう修正

closes #13